### PR TITLE
Fix altitude double decrease

### DIFF
--- a/countingValleys.cpp
+++ b/countingValleys.cpp
@@ -26,14 +26,15 @@ int countingValleys(int steps, string path)
         {
             alt--;
             valleyCount++;
-        }
-        if (path[step] == 'D')
-        {
-            alt--;
-        }
-        else
-        {
-            alt++;
+        } else {
+            if (path[step] == 'D')
+            {
+                alt--;
+            }
+            else
+            {
+                alt++;
+            }
         }
     }
 


### PR DESCRIPTION
Corrección para la situación cuando "step" es 'D' y "alt" es cero entocnes se está decrementando dos veces la variable "alt"
Para testear esto, probar con las siguientes entradas:
steps = 10
path = "DUDDDUUDUU"

El resultado debe ser 2 y el código devolvía 1